### PR TITLE
[#161299373] allow for ios 12 otp autofill as well as copy and paste functionality

### DIFF
--- a/components/ConfirmationCodeInput.js
+++ b/components/ConfirmationCodeInput.js
@@ -207,10 +207,19 @@ export default class ConfirmationCodeInput extends Component {
   
   _onInputCode(character, index) {
     const { codeLength, onFulfill, compareWithCode, ignoreCase } = this.props;
+
     let newCodeArr = _.clone(this.state.codeArr);
-    newCodeArr[index] = character;
+    let currentIndex;
+
+    if (character.length > 1) {
+      newCodeArr = character.slice(0, codeLength).split('')
+      currentIndex = newCodeArr.length - 1;
+    } else {
+      newCodeArr[index] = character;
+      currentIndex = this.state.currentIndex;
+    }
     
-    if (index == codeLength - 1) {
+    if (currentIndex == codeLength - 1) {
       const code = newCodeArr.join('');
       
       if (compareWithCode) {
@@ -220,15 +229,15 @@ export default class ConfirmationCodeInput extends Component {
       } else {
         onFulfill(code);
       }
-      this._blur(this.state.currentIndex);
+      this._blur(currentIndex);
     } else {
-      this._setFocus(this.state.currentIndex + 1);
+      this._setFocus(currentIndex + 1);
     }
-    
+
     this.setState(prevState => {
       return {
         codeArr: newCodeArr,
-        currentIndex: prevState.currentIndex + 1
+        currentIndex: currentIndex + 1
       };
     });
   }
@@ -273,7 +282,6 @@ export default class ConfirmationCodeInput extends Component {
           value={this.state.codeArr[id] ? this.state.codeArr[id].toString() : ''}
           onChangeText={text => this._onInputCode(text, id)}
           onKeyPress={(e) => this._onKeyPress(e)}
-          maxLength={1}
         />
       )
     }


### PR DESCRIPTION
ticket: https://www.pivotaltracker.com/n/projects/1960309/stories/161299373

on ios 12, when getting a one-time-code, you no longer have to go to your text messages. It'll just pop up in app. However, this was not working in our app. Only the first number was being populated. Furthermore, copy-paste functionality wasn't working either. This PR fixes the issue.

Essentially, do the same logic as before, but if the `character.length > 1`, then that means it's either a copy-paste, or the ios-12 one-press otp feature. so make the `newCodeArr` the new character string.

gif of copy paste:
![copy for otp](https://user-images.githubusercontent.com/5386810/47233000-3569ba80-d386-11e8-9a02-13f509117e3b.gif)


gif of ios12 security feature:
![Uploading ios12-otp.gif…]()
