### PR TITLE
comment out width temporarily

### DIFF
--- a/components/ConfirmationCodeInput.js
+++ b/components/ConfirmationCodeInput.js
@@ -35,7 +35,8 @@ export default class ConfirmationCodeInput extends Component {
     inactiveColor: 'rgba(255, 255, 255, 0.2)',
     space: 8,
     compareWithCode: '',
-    ignoreCase: false
+    ignoreCase: false,
+    includeWidth: true
   };
   
   constructor(props) {
@@ -251,13 +252,15 @@ export default class ConfirmationCodeInput extends Component {
       autoFocus,
       className,
       size,
-      activeColor
+      activeColor,
+      includeWidth
     } = this.props;
     
     const initialCodeInputStyle = {
-      width: size,
+      // width: size, TODO(Brandon): Figure out why this line breaks the app on ios for RN 0.59.10 on the confirm SSN screen.
       height: size
     };
+    if (includeWidth) { initialCodeInputStyle.width = size; }
     
     let codeInputs = [];
     for (let i = 0; i < codeLength; i++) {


### PR DESCRIPTION
On the SSN input screen, on ios the app completely breaks after upgrading to react-native 0.59.10. This is solely due to the `width` key.

The crazy thing is that this component is used earlier in confirmphone screen. So it only fails on the ssn input screen.

So fix is to not include the width when when `includeWidth` is specified as false. this is only on the verifyssn screen.

ticket created for this:
https://www.pivotaltracker.com/story/show/167159626